### PR TITLE
fix: implement absolute URL in middleware

### DIFF
--- a/packages/auth/src/middleware.ts
+++ b/packages/auth/src/middleware.ts
@@ -19,7 +19,7 @@ export async function authMiddleware(request: NextRequest) {
         }
     })
     if (!session) {
-        return NextResponse.redirect("/sign-in")
+        NextResponse.redirect(new URL("/sign-in", request.url));
     }
     return NextResponse.next();
 }


### PR DESCRIPTION
Now middleware requires that when requesting a redirect it is necessary to pass an absolute and not a relative url.
See: https://nextjs.org/docs/messages/middleware-relative-urls

![Screenshot 2025-01-19 at 19 28 03](https://github.com/user-attachments/assets/0e1fdf49-5c5a-4541-a76e-6c274c392ef5)
